### PR TITLE
Add plume to small Epstein Drive

### DIFF
--- a/GameData/MEVHeavyIndustries/Parts/mev-EpsteinDriveV4.cfg
+++ b/GameData/MEVHeavyIndustries/Parts/mev-EpsteinDriveV4.cfg
@@ -75,6 +75,31 @@ PART
 				localPosition = 0, 0, 0.08
 			}
 		}
+        running_open
+        {
+            AUDIO
+            {
+                channel = Ship
+                clip = sound_rocket_hard
+                volume = 0.0 0.0
+                volume = 0.05 0.6
+                volume = 1.0 1.5
+                pitch = 0.0 1.2
+                pitch = 1.0 2.0
+                loop = true
+            }
+            MODEL_MULTI_PARTICLE
+            {
+                modelName = Squad/FX/IonPlume
+                transformName = thrustTransform
+                emission = 0.0 0.0
+                emission = 0.1 0.5
+                emission = 1.0 1.0
+                speed = 0.0 0.8
+                speed = 1.0 1.0
+                localPosition = 0, 0, 0.08
+            }
+        }
 		engage 
 		{
 			AUDIO 
@@ -118,7 +143,7 @@ PART
 	{
 		name = ModuleEnginesFX
 		engineID = Cruise
-		runningEffectName = running_closed
+		runningEffectName = running_open
 		thrustVectorTransformName = thrustTransform
 		powerEffectName = shockDiamond
 		exhaustDamage = True


### PR DESCRIPTION
The small Epstein Drive lacks a plume when running in it's "default" mode. This adds a plume; pulled from the previous mod forum topic.

https://forum.kerbalspaceprogram.com/topic/199564-mev-heavy-industries-daedalus-drives-bussard-drives-and-epstein-drives/?do=findComment&comment=4014139